### PR TITLE
Support v2 of Pager Duty REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Working code is worth a thousand words. The basics:
 
 ```ruby
 # setup the connection
-pagerduty = PagerDuty::Connection.new(account, token)
+pagerduty = PagerDuty::Connection.new(token, version)
 
-# 4 main methods: get, post, put, and delete:
+# 4 main methods: `get`, `post`, `put`, and `delete`:
 
-response = pagerduty.get('some/relative/path', :some => 'request', :parameter => 'to pass')
-response = pagerduty.post('some/relative/path', :some => 'request', :parameter => 'to pass')
-response = pagerduty.delete('some/relative/path', :some => 'request', :parameter => 'to pass')
-response = pagerduty.put('some/relative/path', :some => 'request', :parameter => 'to pass')
+response = pagerduty.get('some/relative/path', params)
+response = pagerduty.post('some/relative/path', params)
+response = pagerduty.delete('some/relative/path', params)
+response = pagerduty.put('some/relative/path', params)
 
 # use something like irb or pry to poke around the responses
 # the contents will vary a bit between call, ie:
@@ -63,6 +63,25 @@ response.incidents # an array of incidents
 
 response = pagerduty.get('incidents/YYZ')
 response # the hash/object that represents the array
+```
+
+`get`, `post`, `put`, and `delete` all take a common parameter `params`.
+This parameter contains the query parameters, body, and custom headers
+needed to perform the request. Params is structured as follows:
+
+```ruby
+params = {
+  query_params: {
+    param1: "ABCD",
+    ids: [ "id1", "id2", "id3" ] # Faraday takes care of encoding the arrays to be `?ids[]=id1&ids[]=id2&ids[]=id3..`
+  }, {
+    body: { ... }, # Whatever needs to be sent in a `PUT` or `POST` request body
+  }, {
+    headers: {
+      from: "testuser@test.com" # Some requests require a From header
+    }
+  }
+}
 ```
 
 For more advanced and realistic examples, check out the examples directory:


### PR DESCRIPTION
This commit updates the Connection class to support only v2+ of
the Pager Duty REST API. Updates have been made following the migration
document https://v2.developer.pagerduty.com/docs/migrating-to-api-v2.
Notable v2 updates include:
- Required 'Accept' request header which includes version number
- Base URL has changed, so account_domain is no longer needed
- Rate limiting error handling
- requester_id (user id) is no longer sent as a query parameter to
  identify the requesting user. Instead, set the From header to the
  request user's email address in the headers hash as needed.

In addition to these v2 updates, method signatures have been changed, which
was the main motivation for no longer supporting v1. Prior to
this update, the query parameters were sent through the request body,
which worked for v1 but not for v2.

One of the changes made to v2 was to
restructure the way lists are sent as query parameters. Instead of
having test.com/some_uri?status=status1,status2,status3, we now need to
support
test.com/some_url?statuses[]=status1&statuses[]=status2&statuses[]=status3. Faraday supports encoding query parameters this way, but when sent through the body, arrays are encoded as JSON and so they do not align with what the API requires. Additionally, now that requester_id is added as a header value, it makes sense to separate the request body, headers, and query parameters.

Additionally, we no longer default to any version of the API. The API
version should be sent when initializing PagerDuty::Connection.
