### PR TITLE
Hardcode API version and fix bug with query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ And this is what it doesn't do:
 * have methods for individual API calls that are possible (ie `find_incident`, `list_users`, etc)
 * provide [will_paginate](https://github.com/mislav/will_paginate) or [kaminari](https://github.com/amatsuda/kaminari) paginated arrays (They aren't super documented for building a library that works well with them, and have different APIs)
 
+**Note**: v1 of the Pager Duty REST API is no longer supported with this gem. Please either upgrade to v2 of the API [(v2 Migration Documentation)](https://v2.developer.pagerduty.com/docs/migrating-to-api-v2) or do not upgrade past version 0.2.0 of this gem.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/pager_duty/connection/version.rb
+++ b/lib/pager_duty/connection/version.rb
@@ -1,5 +1,5 @@
 module PagerDuty
   class Connection
-    VERSION = "0.2.0"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
This commit removes the required api_version parameter when initializing
a PagerDuty::Connection object. The reason for this change is that since
this gem no longer supports v1 of the REST API and since we don't know
if there will be future versions of the API or what changes will be made
to future versions, it makes sense to hardcode the value for now.

This commit also fixes a bug that occurs when no query parameters are sent
when performing a GET HTTP request. #get incorrectly expected query parameters
to always be sent because #get modifies the contents of the query params hash.

[151816727386211](https://app.asana.com/0/151816727386211/151816727386211)
